### PR TITLE
[PATCH][EDA-1553] Change sub Modules url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,13 @@
 [submodule "edagames-quoridor"]
 	path = edagames-quoridor
-	url = https://github.com/evbeda/edagames-quoridor
+	url = git@github.com:evbeda/edagames-quoridor.git
 	branch = main
 [submodule "edagames-server"]
 	path = edagames-server
-	url = https://github.com/evbeda/edagames-server
+	url = git@github.com:evbeda/edagames-server.git
 	branch = main
 [submodule "edagames-django"]
 	path = edagames-django
-	url = https://github.com/evbeda/edagames-django
+	url = git@github.com:evbeda/edagames-django.git
 	branch = main
+


### PR DESCRIPTION
Today if I want to clone edagames with submodules I will have problems because submodules links are ins HTTPS format. 
Actually, Github deprecates user/password authentication. So I change HTTP format to SSH format