### PR TITLE
[MINOR][EDA-1612] Add Wumpus in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,18 @@ services:
             - redis
         stdin_open: true # debug pdb
         tty: true # debug pdb
+    wumpus:
+        build: ./edagames-wumpus
+        volumes:
+            - ${PWD}/edagames-wumpus/:/edagames-wumpus/
+        environment:
+            - WUMPUS_GRPC_PORT=50052
+            - REDIS_DB_INDEX=1
+            - REDIS_HOST=redis
+        depends_on:
+            - redis
+        stdin_open: true # debug pdb
+        tty: true # debug pdb
     server:
         build: ./edagames-server
         ports:


### PR DESCRIPTION
For playing wumpus with WebSocket bot. Need to add wumpus image to docker-compose file, with exposing port. To communicate the server with the game