### PR TITLE
[MAJOR][EDA-1640] change docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,11 +59,13 @@ services:
             - WEB_SERVER_URL=django
             - WEB_SERVER_PORT=8000
             - QUORIDOR_HOST_PORT=quoridor:50051
+            - WUMPUS_HOST_PORT=wumpus:50052
             - REDIS_HOST=redis
             # - RABBIT_HOST=rabbit
         depends_on:
             - redis
             - quoridor
+            - wumpus
             # - rabbit
         stdin_open: true # debug pdb
         tty: true # debug pdb


### PR DESCRIPTION
This commit adds wumpus in docker-compose of the Edagames project. So remove quoridor and change the environment variable to expose 5501 port and listen to wumpus 