### PR TITLE
[EDA-1700] adding a CNI patch to increase the avaiable IPs

### DIFF
--- a/kubernetes/edagames/infrastructure/cni-patch.yaml
+++ b/kubernetes/edagames/infrastructure/cni-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: aws-node
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  name: aws-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-node
+        k8s-app: aws-node
+    spec:
+      containers:
+        - name: aws-node
+          env:
+            - name: ENABLE_PREFIX_DELEGATION
+              value: "true"


### PR DESCRIPTION
After running the `terraform apply` AWS didn't create the pod of the server

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/113444840/193892027-c4a04c52-ac37-465f-989f-5d6bea481a65.png">

After a investigation I concluded that the problem is caused because there are not enough resource (In this case IPs) to create the pod. 
So to quickly resolve this problem we patch the CNI, allowing the prefix delegation to IP, so in this way, we increase the number of IP available 