### PR TITLE
[PATCH][EDA-1709]create react Kubernet resource

### DIFF
--- a/kubernetes/edagames/kustomization.yaml
+++ b/kubernetes/edagames/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - quoridor.yaml
   - server.yaml
   - wumpus.yaml
+  - react.yaml

--- a/kubernetes/edagames/react.yaml
+++ b/kubernetes/edagames/react.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: edagames-react
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: edagames-services
+  interval: 10m0s
+  path: ./kubernetes/edagames/react
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  validation: client

--- a/kubernetes/edagames/react/react-deployment.yaml
+++ b/kubernetes/edagames/react/react-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: react
+  name: react
+  namespace: edagames
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: react
+  template:
+    metadata:
+      labels:
+        app: react
+    spec:
+      containers:
+        - image: public.ecr.aws/v1m7n2g6/edagames-react
+          name: server
+          ports:
+            - containerPort: 3000

--- a/kubernetes/edagames/react/react-service.yaml
+++ b/kubernetes/edagames/react/react-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: react
+  name: react
+  namespace: edagames
+spec:
+  ports:
+    - name: react-port
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: react
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: react
+  namespace: edagames
+spec:
+  type: ClusterIP
+  selector:
+    app: react
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000


### PR DESCRIPTION
With this PR. Kubernetes create and discover a react project in port 3000.

Now React only have a default project. The idea of ​​this project is to migrate all Django views to React and transform Django to return JSON to use in React project and no return views