### PR TITLE
[Major][EDA-1725]Elasticache url added to server and wumpus

### DIFF
--- a/kubernetes/edagames/quoridor/quoridor-deployment.yaml
+++ b/kubernetes/edagames/quoridor/quoridor-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 50051
           env:
             - name: REDIS_HOST
-              value: redis-k8s-master
+              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com:6379
             - name: REDIS_DB_INDEX
               value: "1"
             - name: QUORIDOR_GRPC_PORT

--- a/kubernetes/edagames/server/server-deployment.yaml
+++ b/kubernetes/edagames/server/server-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 5000
           env:
             - name: REDIS_HOST
-              value: redis-k8s-master
+              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com:6379
             - name: QUORIDOR_HOST_PORT
               value: quoridor:50051
             - name: TOKEN_KEY


### PR DESCRIPTION
In the first step of the migration of the redis resource from the EKS to the ElastiCache service, the ElastiCache resources were [created](https://github.com/eventbrite/tlz-sandbox-eda-infra/pull/34) by Terraform .

In this step, I only change the current Host of Redis in the server app and in Quoridor app (hard coded) to the ElastiCache cluster URL. With this, we can verify if the apps can communicate with the ElastiCache cluster.

For next steps:

- Verify the correct operation platform
- Delete the redis pod in the EKS
- Put the ElastiCahce url in the Server and Quioridor configMap
