### PR TITLE
elasticache host fixed

### DIFF
--- a/kubernetes/edagames/quoridor/quoridor-deployment.yaml
+++ b/kubernetes/edagames/quoridor/quoridor-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 50051
           env:
             - name: REDIS_HOST
-              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com:6379
+              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com
             - name: REDIS_DB_INDEX
               value: "1"
             - name: QUORIDOR_GRPC_PORT

--- a/kubernetes/edagames/server/server-deployment.yaml
+++ b/kubernetes/edagames/server/server-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - containerPort: 5000
           env:
             - name: REDIS_HOST
-              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com:6379
+              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com
             - name: QUORIDOR_HOST_PORT
               value: quoridor:50051
             - name: WUMPUS_HOST_PORT


### PR DESCRIPTION
The server raises the next exeption:
`raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error -2 connecting to elasticache-edagames.42atol.0001.use1.cache.amazonaws.com:6379:6379. Name or service not known.
INFO:   Error while deleting client connection: An error occurred (GoneException) when calling the DeleteConnection operation:
ERROR:  Client ([agustin1997aguero@gmail.com](mailto:agustin1997aguero@gmail.com)) not found in Redis: Error -2 connecting to elasticache-edagames.42atol.0001.use1.cache.amazonaws.com:**6379:6379.** Name or service not known.`

The problem was in the elasticache url that has the port duplicate.
I fixed this url in Server and in Quoridor