### PR TITLE
harcoding the new apigw id and stage

### DIFF
--- a/kubernetes/edagames/server/server-deployment.yaml
+++ b/kubernetes/edagames/server/server-deployment.yaml
@@ -54,9 +54,9 @@ spec:
                   name: edagames-server-ws-api
                   key: AWS_DEFAULT_REGION
             - name: AWS_APIGATEWAY_ID
-              value: "4yyity02md"
+              value: "9ed2hpyjgj" #"4yyity02md"
             - name: AWS_APIGATEWAY_STAGE
-              value: "ws"
+              value: "ws-clone" #"ws"
             - name: AWS_APIGW_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Now the new api gateway is not working right.
I make a test, with:
-  a bot (`bot_1`)connected to the previous apigw created by hand (`apigw_1`)
- another bot (`bot_2`) connected to the new apigw (`apigw_2`).

When I connected the `bot_2` through the `apigw_2` I could see through the console of the `bot_1` (connected through`apigw_1`) that the `bot_2` was connected. But in the console of the `bot_2` didn't appear anything. 
So my conclusion was that the `apigw_2` was doing good for the connection but, for some reason, the responses from the backend weren't arriving.

I search in the backend where it was declared the apigw URL to return responses and find this:

<img width="962" alt="image" src="https://user-images.githubusercontent.com/113444840/195843741-2078d13d-1167-4ad4-b2d1-4bf6f5bfdfc4.png">

So the URL it's correct. So I search then, these variables which are used to format the apigw URL. I find this in the server `.yaml`

<img width="478" alt="image" src="https://user-images.githubusercontent.com/113444840/195846287-97338d93-e751-4ee0-8705-053753f11053.png">

So currently the server doesn't  know the new apigw

To make a proof of concept I change the `AWS_APIGATEWAY_ID` and `AWS_APIGATEWAY_STAGE` hardcoding the values of the  `apigw_2`.

If this not works, I rollback these changes. If it works I gonna refactor the server to avoid hardcoding the values
