### PR TITLE
[EDA-1810][Patch]remove redis from deployment

### DIFF
--- a/kubernetes/edagames/server/server-deployment.yaml
+++ b/kubernetes/edagames/server/server-deployment.yaml
@@ -21,8 +21,6 @@ spec:
           ports:
             - containerPort: 5000
           env:
-            - name: REDIS_HOST
-              value: elasticache-edagames.42atol.0001.use1.cache.amazonaws.com
             - name: QUORIDOR_HOST_PORT
               value: quoridor:50051
             - name: WUMPUS_HOST_PORT


### PR DESCRIPTION
In the kubernetes server deployment I remove the redis host because the server doesn’t need it anymore